### PR TITLE
config: Remove `theme` key

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -1,5 +1,4 @@
 remote_theme: just-the-docs/just-the-docs
-theme: just-the-docs
 
 plugins:
   - jekyll-titles-from-headings


### PR DESCRIPTION
It creates a build error when deployng remotely on github.io. Local deployment works just fine wihtout it.