### PR TITLE
Improve guidelines for upcoming GSoC contributors

### DIFF
--- a/index.md
+++ b/index.md
@@ -26,11 +26,14 @@ Its content is structured as follows:
 
 ## Become a DLang GSocC Contributor
 
-### Get in Touch
+### First Steps
 
-Throughout GSoC you'll use either our [forums](https://forum.dlang.org/) or [Discord server]() - TODO invite link for communication.
-Use the Discord server to introduce yourself and ask any questions about the DLang environment.
-The community is always happy to help newcomers.
+If you are not currently active in the D community, we encourage you to stop by our online forum and our Community Discord server to say hello.
+There are plenty of helpful people around to welcome you into the community and provide advice and guidance.
+
+- Forums - <https://forum.dlang.org/>
+- Discord - <https://discord.gg/tw2c6mcKAp>
+- You can also contact Mike Parker at social@dlang.org for direct assistance at any stage of the process.
 
 Start with the [Contributor guide](https://wiki.dlang.org/Starting_as_a_Contributor).
 Then make some small contributions.
@@ -44,11 +47,60 @@ We cannot stress this enough: ask the community for guidance whenever you feel s
 
 ### Choose Your Project
 
-Each year we put together a list of potential projects.
-For 2025, the start of the list can be found [here](http://dlang.github.io/gsoc/gsoc-2025/project-ideas.html).
-You can come up with new project ideas either by making a post on the `#projects` channel on our Discord server or by reaching out to our mentors directly.
+Before writing the application, you should have a solid idea of the project you'd like to commit to.
+Your project should require enough effort to keep you occupied throughout the event while also being beneficial to the D community.
+You can find a list of project ideas in [the dlang/project-ideas repository](https://github.com/dlang/project-ideas/)
+Be sure to read through the description on that page.
 
-### Apply
+If none of the ideas in that repository are appealing to you, feel free to propose a different project.
+You might also solicit ideas [in the forums](https://forum.dlang.org/) or [on the Community Discord server](https://discord.gg/tw2c6mcKAp).
+
+With a project selected, it's time to find a mentor.
+Some of the project descriptions in the project ideas repository list potential mentors.
+If not, or if your project idea did not come from that repository, feel free to reach out in the forums, on the Discord server, or to Mike Parker (social@dlang.org) for help finding a mentor.
+
+### The Application
+
+Once you've settled on a project, it's time to write your application. It should contain the following information at the top:
+
+- A descriptive title
+- An email address at which we can contact you
+- Your mentor's name and email address
+
+The remainder of the application should be divided into the following sections: resume, project description, and an optional Extras section.
+
+#### Resume
+
+Briefly explain who you are and why you should be selected.
+Describe any experience you have with the D programming language and/or the language(s) you're most comfortable working with.
+We do not expect applicants to have prior experience with the D programming language, but we want to have a good idea of what your background is.
+Tell us about your experience as a programmer: programming languages you've learned, projects you've worked on, and programming-related topics you've studied.
+We recommend including a link to your GitHub profile if you have any existing work there that you'd like us to see.
+
+#### Project Description
+
+In 800 words or less, describe the project that you are willing to devote several weeks to.
+Why did you select it?
+What specific goals do you want to achieve?
+Can it be completed within the GSoC timeframe, or will it require additional work post-event?
+How will it benefit the D ecosystem and/or community?
+
+At the end of this description, include a rough set of milestones for the project.
+You should work with your mentor on this.
+
+#### Extras
+
+If there is anything that might interfere with your work on this project, e.g., summer school or a job, please let us know here.
+Include any other information you think we should know.
+
+#### Apply
 
 To apply to GSoc, please submit your application on the [official GSoC website](https://summerofcode.withgoogle.com/).
 In 2025 submissions are active between March 24 and April 8.
+
+### Conclusion
+
+All of us in the D community want to see your project succeed.
+We'll do everything we can to help you along the way, starting with your application.
+Please never hesitate to ask for assistance.
+Good luck!


### PR DESCRIPTION
The [old application guide](https://github.com/dlang/project-ideas/blob/master/gsoc-application-guide.md) contained more detailed information about the application process. This commit merges the old guidelines with those already existing in this repo.